### PR TITLE
Write index after adding file, with anyhow for error handling.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ '**' ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,6 +21,6 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Clippy
-      run: cargo test --verbose
+      run: cargo clippy --all-targets -- -D warnings
     - name: Format
       run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +348,7 @@ dependencies = [
 name = "rustygit"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "crossterm 0.23.0",
  "git2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ tui = { version = "0.17", default-features = false, features = ['crossterm', 'se
 crossterm = { version = "0.23", features = [ "serde" ] }
 git2 = "0.14.1"
 serde = "1.0"
+anyhow = "1.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,8 +37,8 @@ impl<'a> App<'a> {
         .list
         .items
         .get(index)
-        .ok_or(anyhow!("Invalid status index"))?;
-      let path = status.path().ok_or(anyhow!("Invalid path"))?;
+        .ok_or_else(|| anyhow!("Invalid status index"))?;
+      let path = status.path().ok_or_else(|| anyhow!("Invalid path"))?;
       let mut index = self.repo.index()?;
       index.add_path(Path::new(path))?;
       index.write()?;

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1,6 +1,4 @@
-use anyhow::{anyhow, Result};
 use crossterm::event::{self, Event, KeyCode};
-
 use std::{
   io,
   time::{Duration, Instant},

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1,4 +1,6 @@
+use anyhow::{anyhow, Result};
 use crossterm::event::{self, Event, KeyCode};
+
 use std::{
   io,
   time::{Duration, Instant},
@@ -27,9 +29,13 @@ pub fn run_app<B: Backend>(
           KeyCode::Left => app.list.unselect(),
           KeyCode::Down => app.list.next(),
           KeyCode::Up => app.list.previous(),
-          KeyCode::Char(' ') => app.primary_action(),
-          _ => {}
-        }
+          KeyCode::Char(' ') => {
+            if let Err(_error) = app.primary_action() {
+              // TODO, display errors in a panel
+            };
+          }
+          _ => (),
+        };
       }
     }
     if last_tick.elapsed() >= tick_rate {


### PR DESCRIPTION
Wraps up our progress from the last session, adding selected file to the git index. 
We were just missing calling `write` to save the index to disk after adding.
Also adds `anyhow` as a start to easier error handling in the app, and fixes the ci config to include clippy and to run on all PRs.