### PR TITLE
Add 'status' section

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,18 @@
-use crate::app::{App, DisplayList};
+use tui::layout::Rect;
+use tui::style::Color;
+use tui::widgets::Paragraph;
 use tui::{
   backend::Backend,
   layout::{Constraint, Direction, Layout},
   style::{Modifier, Style},
-  widgets::{Block, Borders, List, ListItem},
+  widgets::{List, ListItem},
   Frame,
 };
+
+use crate::app::{App, DisplayList};
+use crate::ui::helpers::create_block;
+
+mod helpers;
 
 pub fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
   // Create two chunks with equal horizontal screen space
@@ -14,15 +21,36 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
     .split(f.size());
 
+  render_left_view(f, app, chunks[0]);
+}
+
+pub fn render_left_view<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
+  let chunks = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([Constraint::Length(3), Constraint::Percentage(90)].as_ref())
+    .split(area);
+
+  render_status(f, app, chunks[0]);
+  render_files(f, app, chunks[1])
+}
+
+pub fn render_status<B: Backend>(f: &mut Frame<B>, _app: &mut App, area: Rect) {
+  let paragraph = Paragraph::new("This is the current status")
+    .style(Style::default().fg(Color::White))
+    .block(create_block("Status"));
+  f.render_widget(paragraph, area)
+}
+
+pub fn render_files<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
   // Iterate through all elements in the `items` app and append some debug text to it.
   let items: Vec<ListItem> = app.list.items.list_items();
 
   // Create a List from all list items and highlight the currently selected one
   let items = List::new(items)
-    .block(Block::default().borders(Borders::ALL).title(app.title))
+    .block(create_block(app.title))
     .highlight_style(Style::default().add_modifier(Modifier::BOLD))
     .highlight_symbol(">> ");
 
   // We can now render the item list
-  f.render_stateful_widget(items, chunks[0], &mut app.list.state);
+  f.render_stateful_widget(items, area, &mut app.list.state);
 }

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,0 +1,11 @@
+use tui::style::{Color, Style};
+use tui::text::Span;
+use tui::widgets::{Block, Borders};
+
+// Global styling block
+pub fn create_block(title: &'static str) -> Block {
+  Block::default()
+    .borders(Borders::ALL)
+    .style(Style::default().fg(Color::DarkGray))
+    .title(Span::styled(title, Style::default().fg(Color::Gray)))
+}


### PR DESCRIPTION
* Adds a helper function to create a block component, so all blocks can follow a uniform look.
  * Block has dark grey borders and title text, so improve readability of important information
* Splits the rendering widget UI functions into separate functions, for clearer seperation of components

![Screen Shot 2022-04-08 at 3 21 12 pm](https://user-images.githubusercontent.com/91853657/162370181-8cd324fb-fb77-45c8-948d-99556d14bcf2.png)

